### PR TITLE
validate pid for -p option

### DIFF
--- a/src/utilities.c
+++ b/src/utilities.c
@@ -158,6 +158,11 @@ char *parse_flags(int argc, char *argv[], pid_t *pid, bool *stdout_override, boo
                 fprintf(stderr, "Bad PID %s given, must be integer.\n", optarg);
                 exit(1);
             }
+            // check if the given `pid` is valid
+            if (getpgid(*pid) < 0) {
+                fprintf(stderr, "Bad PID %s given. PID is not valid or does not exist.\n", optarg);
+                exit(1);
+            }
             break;
         case 's':
             *stdout_override = true;

--- a/src/whatfiles.c
+++ b/src/whatfiles.c
@@ -224,7 +224,6 @@ int main(int argc, char* argv[])
 
 /*
 TODO:
-confirm process exists for -p flag
 debug flag for use by hashdriver
 more hashmap tests?
 better allocator/destructor for String


### PR DESCRIPTION
Validate given `pid` to `-p` command-line option to avoid attaching to wrong `pid`.
Also marked one of `todo`s in `whatfiles.c` file as done.